### PR TITLE
Add "submit a pack" popup

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,6 +7,7 @@ html {
 body {
   width: 960px;
   margin: 0px auto;
+  position: relative;
 }
 #packs {
   margin: 40px 0;
@@ -121,4 +122,16 @@ p.code {
 }
 p.code span {
   color: #ada;
+}
+
+#pack-submit {
+  position: absolute;
+  top: 10px;
+  right: 00px;
+  border: 1px solid #f58221;
+  color: #f58221;
+  font-size: 16px;
+  border-radius: 3px;
+  padding: 5px 10px;
+  text-decoration: none;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -1,4 +1,4 @@
-html {
+﻿html {
   font-family: 'Helvetica Neue', Helvetica, 'Open Sans', Arial, sans-serif;
   font-weight: 300;
   font-size: 16px;

--- a/index.html
+++ b/index.html
@@ -4,27 +4,15 @@
   <head>
     <meta charset="UTF-8" />
     <title>StackStorm Exchange</title>
-    <script src="https://npmcdn.com/react@15.3.0/dist/react.min.js"></script>
-    <script src="https://npmcdn.com/react-dom@15.3.0/dist/react-dom.min.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css">
     <link rel="stylesheet" href="css/main.css">
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-46030182-4', 'auto');
-      ga('send', 'pageview');
-    </script>
-    <script type="text/babel" src="js/pack-list.js"></script>
   </head>
 
   <body>
 
     <h1><span>Stack</span>Storm Pack Exchange</h1>
+    <a id="pack-submit" href="#" data-reamaze-lightbox="contact">Submit a pack</a>
     <p class="large">Dozens of ready-made integration packs that make StackStorm complete.</p>
     <p class="code">st2 pack install <span id="pack-install">mypack</span></p>
 
@@ -39,6 +27,42 @@
       </ul>
     </footer>
 
+    <script src="https://npmcdn.com/react@15.3.0/dist/react.min.js"></script>
+    <script src="https://npmcdn.com/react-dom@15.3.0/dist/react-dom.min.js"></script>
+    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-46030182-4', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <script type="text/babel" src="js/pack-list.js"></script>
+    <script type="text/javascript" src="https://d3itxuyrq7vzpz.cloudfront.net/assets/reamaze.js"></script>
+    <script type="text/javascript">
+      var _support = _support || { 'ui': {}, 'user': {} };
+      _support['account'] = 'stackstorm.reamaze.com';
+      _support['custom_fields'] = {
+        source: {
+          type: "hidden",
+          value: "StackStorm Exchange"
+        }
+        slack_username: {
+          type: "text",
+          value: "",
+          placeholder: "Community Slack username",
+          required: true
+        },
+        pack_url: {
+          type: "text",
+          value: "",
+          placeholder: "Pack URL (GitHub preferred)",
+          required: true
+        },
+      }
+    </script>
   </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         source: {
           type: "hidden",
           value: "StackStorm Exchange"
-        }
+        },
         slack_username: {
           type: "text",
           value: "",


### PR DESCRIPTION
This PR adds a "submit a pack" button with a re:Amaze popup. It's a simple pop-up that will send us a pack request with a few extra field (I'm asking for a Slack username and the pack URL). Popup needs to be configured in the future, but for now I'm just using the default lightbox.

There's this button:

<img width="1038" alt="screenshot 2016-08-09 17 09 02" src="https://cloud.githubusercontent.com/assets/145218/17537862/ef192a0a-5e54-11e6-8d05-80bc408132c0.png">

That leads to this popup:

<img width="707" alt="screenshot 2016-08-09 17 09 53" src="https://cloud.githubusercontent.com/assets/145218/17537868/f8d2e838-5e54-11e6-9cd7-f147ad066b7a.png">

That gives us this:

<img width="1025" alt="screenshot 2016-08-09 17 10 08" src="https://cloud.githubusercontent.com/assets/145218/17537873/fe8a798a-5e54-11e6-9584-07846a7bfa7a.png">
