### PR TITLE
Do index updates via GitHub actions

### DIFF
--- a/.github/workflows/update-index.yaml
+++ b/.github/workflows/update-index.yaml
@@ -1,5 +1,12 @@
 name: Update Index
 
+# Only allow one workflow run per branch at a time.
+# When one is already running, new runs will be pending.
+# https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
+concurrency:
+  group: index-update-${{ github.ref }}
+  # Do not use cancel-in-progress! Or we might create a scenario where all workflows get canceled before they complete.
+
 on:
   # every 5 minutes
   #schedule:

--- a/.github/workflows/update-index.yaml
+++ b/.github/workflows/update-index.yaml
@@ -1,0 +1,14 @@
+name: Update Index
+
+on:
+  # every 5 minutes
+  #schedule:
+  #  - cron:  '*/5 * * * *'
+  # manual rebuilds
+  workflow_dispatch:
+
+jobs:
+  update_index:
+    name: 'Update Index'
+    uses: StackStorm-Exchange/ci/.github/workflows/index-update.yaml@gha
+    #with:

--- a/.github/workflows/update-index.yaml
+++ b/.github/workflows/update-index.yaml
@@ -8,14 +8,13 @@ concurrency:
   # Do not use cancel-in-progress! Or we might create a scenario where all workflows get canceled before they complete.
 
 on:
-  # every 5 minutes
-  #schedule:
-  #  - cron:  '*/5 * * * *'
-  # manual rebuilds
+  # every 5 minutes. Increase time if workflows are overlapping.
+  schedule:
+    - cron:  '*/5 * * * *'
+  # manual rebuilds by TSC members
   workflow_dispatch:
 
 jobs:
   update_index:
     name: 'Update Index'
     uses: StackStorm-Exchange/ci/.github/workflows/index-update.yaml@master
-    #with:

--- a/.github/workflows/update-index.yaml
+++ b/.github/workflows/update-index.yaml
@@ -17,5 +17,5 @@ on:
 jobs:
   update_index:
     name: 'Update Index'
-    uses: StackStorm-Exchange/ci/.github/workflows/index-update.yaml@gha
+    uses: StackStorm-Exchange/ci/.github/workflows/index-update.yaml@master
     #with:

--- a/v1/exclude_packs.txt
+++ b/v1/exclude_packs.txt
@@ -1,0 +1,16 @@
+# Any packs in this file are excluded from the index.
+#
+# Each line is a pack name and should be part of the pack's repo name:
+#   StackStorm-Exchange/stackstorm-<pack name here>
+# So, the "foo_bar" pack would be in this repo:
+#   StackStorm-Exchange/stackstorm-foo_bar
+#
+# Comment lines begin with "#"
+
+# utility packs
+test
+test-content-version
+
+# These packs are NOT excluded. CI uses them to test using the index.
+#test2
+#python3_test

--- a/v1/exclude_packs.txt
+++ b/v1/exclude_packs.txt
@@ -9,8 +9,8 @@
 
 # utility packs
 test
+test2
 test-content-version
 
 # These packs are NOT excluded. CI uses them to test using the index.
-#test2
 #python3_test


### PR DESCRIPTION
This is part of migrating from CircleCI to Github Actions: https://github.com/StackStorm/community/issues/63

I just pushed a commit that switches loading commits from @gha to @master.

This depends on https://github.com/StackStorm-Exchange/ci/pull/121